### PR TITLE
Fix a flaky test.

### DIFF
--- a/unirest/src/test/java/BehaviorTests/DefectTest.java
+++ b/unirest/src/test/java/BehaviorTests/DefectTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -48,7 +49,7 @@ class DefectTest extends BddTest {
 
     @Test
     void nullAndObjectValuesInMap() {
-        Map<String, Object> queryParams = new HashMap<>();
+        Map<String, Object> queryParams = new LinkedHashMap<>();
         queryParams.put("foo", null);
         queryParams.put("baz", "qux");
 


### PR DESCRIPTION
1. The test Failure:
- Run the test `BehaviorTests.DefectTest.nullAndObjectValuesInMap` with `mvn -pl unirest edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=BehaviorTests.DefectTest#nullAndObjectValuesInMap`
- About [NonDex](https://github.com/TestingResearchIllinois/NonDex).
- Get some failures: 
```
[ERROR] Failures:
[ERROR]   DefectTest.nullAndObjectValuesInMap:61 expected: <foo&baz=qux> but was: <baz=qux&foo>
```
 2. Why it fails:
-  In `unirest/src/test/java/BehaviorTests/DefectTest.java` : `Map<String, Object> queryParams = new HashMap<>();` ,
 HashMap makes no guarantee about the iteration order.

3. Fix it:
- By changing `HashMap` to `LinkedHashMap`.